### PR TITLE
Add game context badges to user profile page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -162,6 +162,11 @@
               </span>
               <span class="thought-time">
                 Posted <%= time_ago_in_words(thought.created_at) %> ago
+                <% if thought.has_context? %>
+                  <span class="context-badge context-<%= thought.game_context %>">
+                    <%= thought.context_display %>
+                  </span>
+                <% end %>
               </span>
             </div>
           </div>
@@ -183,6 +188,32 @@
 </div>
 
 <style>
+/* Game Context Badges */
+.context-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: bold;
+  margin-left: 8px;
+  text-transform: uppercase;
+}
+
+.context-before {
+  background-color: #e3f2fd;
+  color: #1976d2;
+}
+
+.context-during {
+  background-color: #e8f5e8;
+  color: #2e7d32;
+}
+
+.context-after {
+  background-color: #fce4ec;
+  color: #c2185b;
+}
+
 /* Add new styles for follow functionality */
 .follow-actions {
   margin: 15px 0;


### PR DESCRIPTION
- Display game context badges next to game thoughts on profile page
- Include same styling as game detail page for consistency
- Show when thoughts were posted relative to game timeline